### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,12 @@
 django-generic-m2m
 ==================
 
-relate anything to anything.  the image below is a screenshot of the `example app <http://readthedocs.org/docs/django-generic-m2m/en/latest/example.html>`_ 
+relate anything to anything.  the image below is a screenshot of the `example app <https://django-generic-m2m.readthedocs.io/en/latest/example.html>`_ 
 and shows a blog post that has been "related" to 2 "Place" models and a "City" model:
 
 .. image:: http://media.charlesleifer.com/images/photos/genericm2m-tagging.png
 
-check the `documentation <http://readthedocs.org/docs/django-generic-m2m/en/latest/>`_ for
+check the `documentation <https://django-generic-m2m.readthedocs.io/en/latest/>`_ for
 more examples and an in-depth description of the app (or keep reading for
 the 30 second version).
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.